### PR TITLE
fixed detail command issue #47

### DIFF
--- a/pygeoweaver/commands/pgw_detail.py
+++ b/pygeoweaver/commands/pgw_detail.py
@@ -1,34 +1,69 @@
 """
-Detail subcommand
+Detail subcommand with integrated server management.
 """
 
 import logging
 import subprocess
-
 import requests
 from pygeoweaver.constants import *
-
 from pygeoweaver.utils import (
     download_geoweaver_jar,
     get_geoweaver_jar_path,
     get_java_bin_path,
     get_root_dir,
     get_spinner,
+    check_os,
+)
+from pygeoweaver.server import (
+    start_on_windows,
+    start_on_mac_linux,
+    check_geoweaver_status,
+    stop_on_windows,
+    stop_on_mac_linux,
 )
 
 logger = logging.getLogger(__name__)
 
+def ensure_server_running(force_restart=False, force_download=False):
+    """
+    Ensure the Geoweaver server is running. If not, start it.
+    
+    :param force_restart: Restart the server even if it's already running.
+    :param force_download: Force download of Geoweaver jar if necessary.
+    """
+    if not force_restart and check_geoweaver_status():
+        logger.info("Geoweaver server is already running.")
+        return
+    
+    logger.info("Starting Geoweaver server...")
+    
+    # Determine the operating system and start accordingly
+    os_type = check_os()
+    if os_type == 3:  # Windows
+        start_on_windows(force_restart=force_restart, force_download=force_download, exit_on_finish=False)
+    else:  # macOS or Linux
+        start_on_mac_linux(force_restart=force_restart, force_download=force_download, exit_on_finish=False)
+    
+    # Verify server status after starting
+    if not check_geoweaver_status():
+        raise RuntimeError("Failed to start Geoweaver server. Please check logs for details.")
 
-def detail_workflow(workflow_id):
+def detail_workflow(workflow_id, force_restart=False, force_download=False):
     """
     Display detailed information about a workflow.
 
     :param workflow_id: The ID of the workflow.
     :type workflow_id: str
+    :param force_restart: Restart the server even if it's already running.
+    :param force_download: Force download of Geoweaver jar if necessary.
     """
     if not workflow_id:
-        raise RuntimeError("Workflow id is missing")
-    with get_spinner(text="Getting host details..", spinner="dots"):
+        raise RuntimeError("Workflow ID is missing.")
+    
+    # Ensure server is running before proceeding
+    ensure_server_running(force_restart=force_restart, force_download=force_download)
+    
+    with get_spinner(text="Getting workflow details...", spinner="dots"):
         download_geoweaver_jar()
         process = subprocess.run(
             [
@@ -46,18 +81,23 @@ def detail_workflow(workflow_id):
         print("=== Error ===")
         print(process.stderr)
         logger.error(process.stderr)
-        
 
-def detail_process(process_id):
+def detail_process(process_id, force_restart=False, force_download=False):
     """
     Display detailed information about a process.
 
     :param process_id: The ID of the process.
     :type process_id: str
+    :param force_restart: Restart the server even if it's already running.
+    :param force_download: Force download of Geoweaver jar if necessary.
     """
     if not process_id:
-        raise RuntimeError("Process id is missing")
-    with get_spinner(text="Getting host details..", spinner="dots"):
+        raise RuntimeError("Process ID is missing.")
+    
+    # Ensure server is running before proceeding
+    ensure_server_running(force_restart=force_restart, force_download=force_download)
+    
+    with get_spinner(text="Getting process details...", spinner="dots"):
         download_geoweaver_jar()
         process = subprocess.run(
             [
@@ -75,16 +115,22 @@ def detail_process(process_id):
         print(process.stderr)
         logger.error(process.stderr)
 
-def detail_host(host_id):
+def detail_host(host_id, force_restart=False, force_download=False):
     """
     Display detailed information about a host.
 
     :param host_id: The ID of the host.
     :type host_id: str
+    :param force_restart: Restart the server even if it's already running.
+    :param force_download: Force download of Geoweaver jar if necessary.
     """
     if not host_id:
-        raise RuntimeError("Host id is missing")
-    with get_spinner(text="Getting host details..", spinner="dots"):
+        raise RuntimeError("Host ID is missing.")
+    
+    # Ensure server is running before proceeding
+    ensure_server_running(force_restart=force_restart, force_download=force_download)
+    
+    with get_spinner(text="Getting host ...", spinner="dots"):
         download_geoweaver_jar()
         process = subprocess.run(
             [
@@ -96,22 +142,26 @@ def detail_host(host_id):
             ],
             cwd=f"{get_root_dir()}/",
         )
-    
     print(process.stdout)
     if process.stderr:
         print("=== Error ===")
         print(process.stderr)
         logger.error(process.stderr)
 
-def get_process_code(process_id):
+def get_process_code(process_id, force_restart=False, force_download=False):
     """
     Get the code of a process.
 
     :param process_id: The ID of the process.
     :type process_id: str
+    :param force_restart: Restart the server even if it's already running.
+    :param force_download: Force download of Geoweaver jar if necessary.
     :return: The code of the process.
     :rtype: str
     """
+    # Ensure server is running before proceeding
+    ensure_server_running(force_restart=force_restart, force_download=force_download)
+    
     r = requests.post(
         f"{GEOWEAVER_DEFAULT_ENDPOINT_URL}/web/detail",
         data={"type": "process", "id": process_id},


### PR DESCRIPTION
Hi, this is Prasoona Ganaparthi, a student at George Mason University. While exploring open-source projects, I came across yours and found it incredibly interesting. I noticed an issue that was posted on GitHub and decided to work on it. After setting up the environment on my system, I worked on resolving the issue and would love your feedback on my approach.

This pull request fixes the issue where the detail command doesn't automatically start the server if not already. With this update, the server will automatically start if it is not running when executing any detail subcommand (workflow, process, host, or get_process_code).

Code Changes:
1. Added ensure_server_running Function:
    Ensures the Geoweaver server is running before executing a detail command.
    Starts the server based on the user's operating system (Windows, macOS, or Linux).
    Includes parameters for forced server restart or forced jar download (force_restart and force_download).
    
2. Integrated ensure_server_running Across detail Subcommands:
    detail_workflow, detail_process, detail_host, and get_process_code now call ensure_server_running before proceeding 
    with their logic.

Testing Results:
Tested the changes in the local environment on macOS. Below are some test commands and their outputs:

Stop server and list processes:
    gw stop
    gw list process
    Output: Successfully stopped Geoweaver and listed processes without issues.

Start server automatically via detail command:
    gw detail code z56pry
    Output: Successfully started Geoweaver server and displayed the process details.

Get host details via detail command:
    gw detail host 100001
    Output: Server started automatically, and host details were retrieved successfully.

Request for Testing:
Please test the following scenarios:
1. Execute detail commands without the server running to verify it starts automatically.
2. Test with force_restart=True and force_download=True to ensure proper server reinitialization.
3. Confirm compatibility across Windows, macOS, and Linux.

Looking forward to contribute more this project.