### PR TITLE
Resolves import pygeoweaver issue in windows

### DIFF
--- a/pygeoweaver/pgw_log_config.py
+++ b/pygeoweaver/pgw_log_config.py
@@ -21,7 +21,7 @@ def setup_logging():
     # Open the pgw_logging.ini file
     with open(logging_ini_path, 'rt') as f:
         config_str = f.read()
-        config_str = config_str.replace('%(log_file)s', os.path.expanduser(log_file))
+        config_str = config_str.replace('%(log_file)s', os.path.abspath(log_file).replace('\\', '/'))
 
     config_file = f'{current_folder}/logging_temp.ini'
     with open(config_file, 'wt') as f:


### PR DESCRIPTION
Earlier `import pygeoweaver` caused an error in windows. This PR resolves that, please follow the steps below to test this PR on your OS.

Installation requirements,
-  pip
- python
- git (only to test this PR, once merged into main branch `pip install pygeoweaver` is used)

1. Open your terminal/command prompt.
2. Check if you have pygeoweaver installed `pip show pygeoweaver`
3. If it shows a version, uninstall using `pip uninstall pygeoweaver`
4. Now execute this command to install pygeoweaver version in import-pygeoweaver-windows branch.
`pip install git+https://github.com/ESIPFed/pygeoweaver.git@import-pygeoweaver-windows`
5. Open python in terminal using command `python`
6. Import library `import pygeoweaver`
7. Check if you are able to start geoweaver with command `pygeoweaver.start()` and verify if it is accessible through your [localhost](http://localhost:8070/Geoweaver/web/geoweaver)
